### PR TITLE
flatten class structure

### DIFF
--- a/avrogen/dict_wrapper.py
+++ b/avrogen/dict_wrapper.py
@@ -29,7 +29,7 @@ if six.PY3:
         def values(self):
             return self._inner_dict.values()
 
-        def fromkeys(S, v=None):
+        def fromkeys(self, v=None):
             raise NotImplementedError
 
         def clear(self):
@@ -132,7 +132,7 @@ else:
         def viewvalues(self):
             return self._inner_dict.viewvalues()
 
-        def fromkeys(S, v=None):
+        def fromkeys(self, v=None):
             raise NotImplementedError
 
         def clear(self):
@@ -145,7 +145,7 @@ else:
             return self._inner_dict.get(k, d)
 
         def has_key(self, k):
-            return self._inner_dict.has_key(key)
+            return self._inner_dict.has_key(k)
 
         def __contains__(self, item):
             return self._inner_dict.__contains__(item)

--- a/avrogen/schema.py
+++ b/avrogen/schema.py
@@ -4,16 +4,10 @@ import os
 import six
 from avro import schema
 
-if six.PY3:
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from io import StringIO
 
 
-if six.PY3:
-    from avro.schema import SchemaFromJSONData as make_avsc_object
-else:
-    from avro.schema import make_avsc_object
+from avro.schema import SchemaFromJSONData as make_avsc_object
 
 from .core_writer import generate_namespace_modules, clean_fullname
 from .tabbed_writer import TabbedWriter
@@ -55,17 +49,12 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
     write_get_schema(writer)
     write_populate_schemas(writer)
 
-    writer.write('\n\n\nclass SchemaClasses(object):')
-    writer.tab()
-    writer.write('\n\n')
-
     current_namespace = tuple()
 
     for name, field_schema in names:  # type: str, schema.Schema
         name = clean_fullname(name)
         namespace = tuple(name.split('.')[:-1])
         if namespace != current_namespace:
-            start_namespace(current_namespace, namespace, writer)
             current_namespace = namespace
         if isinstance(field_schema, schema.RecordSchema):
             logger.debug('Writing schema: %s', clean_fullname(field_schema.fullname))
@@ -73,13 +62,12 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
         elif isinstance(field_schema, schema.EnumSchema):
             logger.debug('Writing enum: %s', field_schema.fullname)
             write_enum(field_schema, writer)
-    writer.write('\npass\n')
     writer.set_tab(0)
     writer.write('\n__SCHEMA_TYPES = {\n')
     writer.tab()
 
     for name, field_schema in names:
-        writer.write("'%s': SchemaClasses.%sClass,\n" % (clean_fullname(field_schema.fullname), clean_fullname(field_schema.fullname)))
+        writer.write("'%s': %sClass,\n" % (clean_fullname(field_schema.name), clean_fullname(field_schema.name)))
 
     writer.untab()
     writer.write('\n}\n')
@@ -104,7 +92,7 @@ def write_schema_preamble(writer):
         writer.write('\nnames = avro_schema.Names()')
         writer.write('\nschema = make_avsc_object(json.loads(__read_file(file_name)), names)')
         writer.write('\nreturn names, schema')
-    writer.write('\n\n__NAMES, SCHEMA = __get_names_and_schema(os.path.join(os.path.dirname(__file__), "schema.avsc"))')
+    writer.write('\n\n\n__NAMES, SCHEMA = __get_names_and_schema(os.path.join(os.path.dirname(__file__), "schema.avsc"))')
 
 
 def write_populate_schemas(writer):
@@ -129,9 +117,13 @@ def write_namespace_modules(ns_dict, output_folder):
             currency = '.'
             if ns != '':
                 currency += '.' * len(ns.split('.'))
-            f.write('from {currency}schema_classes import SchemaClasses\n'.format(currency=currency))
             for name in ns_dict[ns]:
-                f.write("{name} = SchemaClasses.{ns}{name}Class\n".format(name=name, ns=ns if not ns else (ns + ".")))
+                f.write('from {0}schema_classes import {1}Class\n'.format(currency, name))
+
+            f.write('\n\n')
+
+            for name in ns_dict[ns]:
+                f.write("{name} = {name}Class\n".format(name=name))
 
 
 def write_specific_reader(record_types, output_folder, use_logical_types):
@@ -143,7 +135,9 @@ def write_specific_reader(record_types, output_folder, use_logical_types):
     """
     with open(os.path.join(output_folder, "__init__.py"), "a+") as f:
         writer = TabbedWriter(f)
-        writer.write('\n\nfrom .schema_classes import SchemaClasses, SCHEMA as my_schema, get_schema_type')
+        writer.write('from .schema_classes import SCHEMA as get_schema_type')
+        for t in record_types:
+            writer.write('\nfrom .schema_classes import {}Class'.format(t.split('.')[1]))
         writer.write('\nfrom avro.io import DatumReader')
         if use_logical_types:
             writer.write('\nfrom avrogen import logical')


### PR DESCRIPTION
This merge flattens the class structure of the generated classes.

The reasoning for this is the following:
 - We use a directory based approach to access nested classes. Because of this, having nested classes in a single file doesn't make much sense.
 - This provides a much easier to read output.

Some might note the haphazard coding style, but that is in a attempt to match the given implementation of the generator, and will be fixed in #2 