### PR TITLE
Draft: Avro Backwards Transitive Null check

### DIFF
--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -129,7 +129,7 @@ def write_setters(record, writer, use_logical_types=False):
     writer.write('    err = set(inner_dict.keys()) - set(field_names)\n')
     writer.write('    test_keys = []\n')
     writer.write('    for e in err:\n')
-    writer.write('        if inner_dict[e] is None:\n')
+    writer.write('        if inner_dict[e] is not None:\n')
     writer.write('            test_keys.append(e)\n')
     writer.write('    if test_keys:\n')
     writer.write('        raise KeyError(f"Keys from provided object are not subset of object params in {type(self).__name__}: {err}")\n')

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -127,7 +127,12 @@ def write_setters(record, writer, use_logical_types=False):
 
     writer.write('if set(inner_dict.keys()) - set(field_names):\n')
     writer.write('    err = set(inner_dict.keys()) - set(field_names)\n')
-    writer.write('    raise KeyError(f"Keys from provided object are not subset of object params in {type(self).__name__}: {err}")\n')
+    writer.write('    test_keys = []\n')
+    writer.write('    for e in err:\n')
+    writer.write('        if inner_dict[e] is None:\n')
+    writer.write('            test_keys.append(e)\n')
+    writer.write('    if test_keys:\n')
+    writer.write('        raise KeyError(f"Keys from provided object are not subset of object params in {type(self).__name__}: {err}")\n')
 
     for field in record.fields:
         f_name = field.name


### PR DESCRIPTION
On certain schema migrations, the backwards transitive check may not offer full backwards compatibility on moved fields. This PR adds a check to see if a field that is not present (from an older schema) can be excluded only if it is None.